### PR TITLE
Fix undefined reference to yylex: Only link FLEX_LIBRARIES on Apple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ ADD_FLEX_BISON_DEPENDENCY(MyScanner MyParser)
 add_executable(STLRomParser ${SOURCE_FILES} ${HEADER_FILES} ${BISON_MyParser_OUTPUTS} ${FLEX_MyScanner_OUTPUTS})
 
 # --- MAC OS FIX: Link Flex Library (libfl) to your executable ---
-if(FLEX_LIBRARIES)
+if(APPLE AND FLEX_LIBRARIES)
     target_link_libraries(STLRomParser PRIVATE ${FLEX_LIBRARIES})
 endif()
 # ----------------------------------------------------------------


### PR DESCRIPTION
On Arch, building STLRom fails with "undefined reference to `yylex'". Declaring a C yylex function does not fix the issue. According to https://github.com/Seifert69/DikuMUD3/issues/70#issuecomment-1100932157, a possible cause is linking FLEX_LIBRARIES, which was added to CMakeLists.txt as a fix for MacOS in 246fd9d. This commit fixes the issue by only linking FLEX_LIBRARIES when they are defined AND when building on MacOS.